### PR TITLE
Use tern plugin threejs.js instead of JSON Type Definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tern-threejs",
   "version": "0.1.0",
-  "main": "threejs.json",
+  "main": "threejs.js",
   "description": "A Tern plugin adding support for three.js.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR uses the tern plugin  threejs.js instead of JSON Type Definition with node. Could you too remove th ethreejs.json from your repository too. Thanks!